### PR TITLE
Main

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -146,7 +146,6 @@ main{
     font-size: 1.7em;
     display: flex;
     flex-direction: column;
-    gap: 30px;
 }
 
 main h2{


### PR DESCRIPTION
Retirei o estilo 'gap:30px' na linha 149 do arquivo main.css e pareceu funcionar, o gráfico volta a aparecer normalmente no navegador em tela cheia :).